### PR TITLE
feat: hotkeys sharon

### DIFF
--- a/graphyne-client/src/components/UI/HotkeyManager.tsx
+++ b/graphyne-client/src/components/UI/HotkeyManager.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "../../store/store";
+import {
+  fetchHotkeys, createHotkey, updateHotkey,
+  deleteHotkey, setEditingId
+} from "../../store/hotkeySlice";
+import { RESERVED_KEYS, DEFAULT_HOTKEYS } from "../../types/hotkey";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default function HotkeyManager({ isOpen, onClose }: Props) {
+  const dispatch = useDispatch<AppDispatch>();
+  const { items, status, editingId } = useSelector((s: RootState) => s.hotkeys);
+
+  const [newAction, setNewAction] = useState("");
+  const [newKeys, setNewKeys]     = useState("");
+  const [editKeys, setEditKeys]   = useState("");
+  const [error, setError]         = useState("");
+
+  useEffect(() => {
+    if (isOpen) dispatch(fetchHotkeys());
+  }, [isOpen, dispatch]);
+
+  // Normalise key combo for comparison e.g "Ctrl+S" → "ctrl+s"
+  const normalise = (keys: string) => keys.toLowerCase().trim();
+
+  const isReserved = (keys: string) =>
+    RESERVED_KEYS.map(k => k.toLowerCase()).includes(normalise(keys));
+
+  const isDuplicate = (keys: string, excludeId?: string) =>
+    items.some(h => normalise(h.keys) === normalise(keys) && h.id !== excludeId);
+
+  // CREATE
+  const handleCreate = () => {
+    setError("");
+    if (!newAction.trim()) return setError("Action name is required.");
+    if (!newKeys.trim())   return setError("Key combination is required.");
+    if (isReserved(newKeys)) return setError("That key combination is reserved by the editor and cannot be used.");
+    if (isDuplicate(newKeys)) return setError("That key combination is already assigned.");
+    dispatch(createHotkey({ action: newAction.trim(), keys: newKeys.trim() }));
+    setNewAction("");
+    setNewKeys("");
+  };
+
+  // UPDATE
+  const handleUpdate = (id: string) => {
+    setError("");
+    if (!editKeys.trim()) return setError("Key combination is required.");
+    if (isReserved(editKeys)) return setError("That key combination is reserved by the editor and cannot be used.");
+    if (isDuplicate(editKeys, id)) return setError("That key combination is already assigned.");
+    dispatch(updateHotkey({ id, keys: editKeys.trim() }));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-[#16181c] border border-[#2e3140] rounded-2xl w-[560px] max-h-[80vh] flex flex-col overflow-hidden">
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[#2e3140] shrink-0">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Hotkey Manager</h2>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Reserved editor shortcuts cannot be overridden
+            </p>
+          </div>
+          <button onClick={onClose} className="text-slate-500 hover:text-white text-xl leading-none">×</button>
+        </div>
+
+        <div className="overflow-y-auto flex-1 p-5 space-y-5">
+
+          {/* Reserved keys — read only display */}
+          <div>
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
+              Reserved (locked)
+            </p>
+            <div className="grid grid-cols-2 gap-1">
+              {RESERVED_KEYS.map(k => (
+                <div key={k} className="flex items-center justify-between px-3 py-1.5 bg-[#0e0f11] rounded-lg border border-[#2e3140]">
+                  <span className="text-xs text-slate-500 truncate">{k}</span>
+                  <span className="text-[10px] text-slate-600 ml-2 shrink-0">locked</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* User-defined hotkeys */}
+          <div>
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
+              Custom hotkeys
+            </p>
+            {status === "loading" && (
+              <p className="text-xs text-slate-500">Loading...</p>
+            )}
+            {items.length === 0 && status !== "loading" && (
+              <p className="text-xs text-slate-500">No custom hotkeys yet.</p>
+            )}
+            <div className="space-y-1">
+              {items.map(hotkey => (
+                <div key={hotkey.id} className="flex items-center gap-2 px-3 py-2 bg-[#0e0f11] rounded-lg border border-[#2e3140]">
+                  <span className="text-xs text-white flex-1 truncate">{hotkey.action}</span>
+
+                  {editingId === hotkey.id ? (
+                    <>
+                      <input
+                        autoFocus
+                        value={editKeys}
+                        onChange={e => setEditKeys(e.target.value)}
+                        placeholder="e.g. ctrl+shift+r"
+                        className="bg-[#16181c] border border-[#2e3140] rounded px-2 py-1 text-xs text-white w-36 focus:outline-none focus:border-violet-500"
+                      />
+                      <button
+                        onClick={() => handleUpdate(hotkey.id)}
+                        disabled={status === "saving"}
+                        className="text-xs px-2 py-1 bg-violet-600 hover:bg-violet-700 text-white rounded disabled:opacity-50"
+                      >
+                        Save
+                      </button>
+                      <button
+                        onClick={() => dispatch(setEditingId(null))}
+                        className="text-xs px-2 py-1 border border-[#2e3140] text-slate-400 hover:text-white rounded"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <kbd className="bg-[#2a2d35] border border-[#3a3f50] rounded px-2 py-0.5 text-xs font-mono text-slate-300">
+                        {hotkey.keys}
+                      </kbd>
+                      <button
+                        onClick={() => { dispatch(setEditingId(hotkey.id)); setEditKeys(hotkey.keys); setError(""); }}
+                        className="text-xs text-slate-500 hover:text-violet-400 transition-colors"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => dispatch(deleteHotkey(hotkey.id))}
+                        className="text-xs text-slate-500 hover:text-red-400 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Create new hotkey */}
+          <div>
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
+              Add new hotkey
+            </p>
+            <div className="space-y-2">
+              <input
+                value={newAction}
+                onChange={e => setNewAction(e.target.value)}
+                placeholder="Action name (e.g. Toggle Sidebar)"
+                className="w-full bg-[#0e0f11] border border-[#2e3140] rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-violet-500"
+              />
+              <input
+                value={newKeys}
+                onChange={e => setNewKeys(e.target.value)}
+                placeholder="Keys (e.g. ctrl+shift+s)"
+                className="w-full bg-[#0e0f11] border border-[#2e3140] rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-violet-500"
+              />
+              {error && (
+                <p className="text-xs text-red-400">{error}</p>
+              )}
+              <button
+                onClick={handleCreate}
+                className="w-full py-2 bg-violet-600 hover:bg-violet-700 text-white text-xs font-medium rounded-lg transition-colors"
+              >
+                Add Hotkey
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/graphyne-client/src/components/UI/HotkeyManager.tsx
+++ b/graphyne-client/src/components/UI/HotkeyManager.tsx
@@ -5,7 +5,7 @@ import {
   fetchHotkeys, createHotkey, updateHotkey,
   deleteHotkey, setEditingId
 } from "../../store/hotkeySlice";
-import { RESERVED_KEYS, DEFAULT_HOTKEYS } from "../../types/hotkey";
+import { RESERVED_KEYS } from "../../types/hotkey";
 
 type Props = {
   isOpen: boolean;

--- a/graphyne-client/src/components/UI/HotkeyManager.tsx
+++ b/graphyne-client/src/components/UI/HotkeyManager.tsx
@@ -2,8 +2,11 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../../store/store";
 import {
-  fetchHotkeys, createHotkey, updateHotkey,
-  deleteHotkey, setEditingId
+  fetchHotkeys,
+  createHotkey,
+  updateHotkey,
+  deleteHotkey,
+  setEditingId,
 } from "../../store/hotkeySlice";
 import { RESERVED_KEYS } from "../../types/hotkey";
 
@@ -14,44 +17,65 @@ type Props = {
 
 export default function HotkeyManager({ isOpen, onClose }: Props) {
   const dispatch = useDispatch<AppDispatch>();
-  const { items, status, editingId } = useSelector((s: RootState) => s.hotkeys);
+  const { items, status, editingId } = useSelector(
+    (s: RootState) => s.hotkeys
+  );
 
   const [newAction, setNewAction] = useState("");
-  const [newKeys, setNewKeys]     = useState("");
-  const [editKeys, setEditKeys]   = useState("");
-  const [error, setError]         = useState("");
+  const [newKeys, setNewKeys] = useState("");
+  const [editKeys, setEditKeys] = useState("");
+  const [error, setError] = useState("");
 
   useEffect(() => {
-    if (isOpen) dispatch(fetchHotkeys());
-  }, [isOpen, dispatch]);
+    if (isOpen && status === "idle") {
+      dispatch(fetchHotkeys());
+    }
+  }, [isOpen, status, dispatch]);
 
-  // Normalise key combo for comparison e.g "Ctrl+S" → "ctrl+s"
   const normalise = (keys: string) => keys.toLowerCase().trim();
 
   const isReserved = (keys: string) =>
-    RESERVED_KEYS.map(k => k.toLowerCase()).includes(normalise(keys));
+    RESERVED_KEYS.map((k) => k.toLowerCase()).includes(normalise(keys));
 
   const isDuplicate = (keys: string, excludeId?: string) =>
-    items.some(h => normalise(h.keys) === normalise(keys) && h.id !== excludeId);
+    items.some(
+      (h) => normalise(h.keys) === normalise(keys) && h.id !== excludeId
+    );
 
-  // CREATE
   const handleCreate = () => {
     setError("");
+
     if (!newAction.trim()) return setError("Action name is required.");
-    if (!newKeys.trim())   return setError("Key combination is required.");
-    if (isReserved(newKeys)) return setError("That key combination is reserved by the editor and cannot be used.");
-    if (isDuplicate(newKeys)) return setError("That key combination is already assigned.");
-    dispatch(createHotkey({ action: newAction.trim(), keys: newKeys.trim() }));
+    if (!newKeys.trim()) return setError("Key combination is required.");
+    if (isReserved(newKeys))
+      return setError(
+        "That key combination is reserved by the editor and cannot be used."
+      );
+    if (isDuplicate(newKeys))
+      return setError("That key combination is already assigned.");
+
+    dispatch(
+      createHotkey({
+        action: newAction.trim(),
+        keys: newKeys.trim(),
+      })
+    );
+
     setNewAction("");
     setNewKeys("");
   };
 
-  // UPDATE
   const handleUpdate = (id: string) => {
     setError("");
+
     if (!editKeys.trim()) return setError("Key combination is required.");
-    if (isReserved(editKeys)) return setError("That key combination is reserved by the editor and cannot be used.");
-    if (isDuplicate(editKeys, id)) return setError("That key combination is already assigned.");
+    if (isReserved(editKeys))
+      return setError(
+        "That key combination is reserved by the editor and cannot be used."
+      );
+    if (isDuplicate(editKeys, id))
+      return setError("That key combination is already assigned.");
+
     dispatch(updateHotkey({ id, keys: editKeys.trim() }));
   };
 
@@ -60,88 +84,98 @@ export default function HotkeyManager({ isOpen, onClose }: Props) {
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
       <div className="bg-[#16181c] border border-[#2e3140] rounded-2xl w-[560px] max-h-[80vh] flex flex-col overflow-hidden">
-
-        {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-[#2e3140] shrink-0">
           <div>
-            <h2 className="text-sm font-semibold text-white">Hotkey Manager</h2>
+            <h2 className="text-sm font-semibold text-white">
+              Hotkey Manager
+            </h2>
             <p className="text-xs text-slate-500 mt-0.5">
               Reserved editor shortcuts cannot be overridden
             </p>
           </div>
-          <button onClick={onClose} className="text-slate-500 hover:text-white text-xl leading-none">×</button>
+          <button
+            onClick={onClose}
+            className="text-slate-500 hover:text-white text-xl leading-none"
+          >
+            ×
+          </button>
         </div>
 
         <div className="overflow-y-auto flex-1 p-5 space-y-5">
-
-          {/* Reserved keys — read only display */}
+          {/* Reserved */}
           <div>
-            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
+            <p className="text-xs font-semibold text-slate-400 uppercase mb-2">
               Reserved (locked)
             </p>
             <div className="grid grid-cols-2 gap-1">
-              {RESERVED_KEYS.map(k => (
-                <div key={k} className="flex items-center justify-between px-3 py-1.5 bg-[#0e0f11] rounded-lg border border-[#2e3140]">
-                  <span className="text-xs text-slate-500 truncate">{k}</span>
-                  <span className="text-[10px] text-slate-600 ml-2 shrink-0">locked</span>
+              {RESERVED_KEYS.map((k) => (
+                <div
+                  key={k}
+                  className="flex justify-between px-3 py-1.5 bg-[#0e0f11] rounded-lg border border-[#2e3140]"
+                >
+                  <span className="text-xs text-slate-500">{k}</span>
+                  <span className="text-[10px] text-slate-600">locked</span>
                 </div>
               ))}
             </div>
           </div>
 
-          {/* User-defined hotkeys */}
+          {/* Custom */}
           <div>
-            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
+            <p className="text-xs font-semibold text-slate-400 uppercase mb-2">
               Custom hotkeys
             </p>
+
             {status === "loading" && (
               <p className="text-xs text-slate-500">Loading...</p>
             )}
-            {items.length === 0 && status !== "loading" && (
-              <p className="text-xs text-slate-500">No custom hotkeys yet.</p>
-            )}
+
             <div className="space-y-1">
-              {items.map(hotkey => (
-                <div key={hotkey.id} className="flex items-center gap-2 px-3 py-2 bg-[#0e0f11] rounded-lg border border-[#2e3140]">
-                  <span className="text-xs text-white flex-1 truncate">{hotkey.action}</span>
+              {items.map((hotkey) => (
+                <div
+                  key={hotkey.id}
+                  className="flex items-center gap-2 px-3 py-2 bg-[#0e0f11] rounded-lg border border-[#2e3140]"
+                >
+                  <span className="text-xs text-white flex-1">
+                    {hotkey.action}
+                  </span>
 
                   {editingId === hotkey.id ? (
                     <>
                       <input
                         autoFocus
                         value={editKeys}
-                        onChange={e => setEditKeys(e.target.value)}
-                        placeholder="e.g. ctrl+shift+r"
-                        className="bg-[#16181c] border border-[#2e3140] rounded px-2 py-1 text-xs text-white w-36 focus:outline-none focus:border-violet-500"
+                        onChange={(e) => {
+                          setEditKeys(e.target.value);
+                          setError("");
+                        }}
+                        className="w-36 text-xs"
                       />
-                      <button
-                        onClick={() => handleUpdate(hotkey.id)}
-                        disabled={status === "saving"}
-                        className="text-xs px-2 py-1 bg-violet-600 hover:bg-violet-700 text-white rounded disabled:opacity-50"
-                      >
+                      <button onClick={() => handleUpdate(hotkey.id)}>
                         Save
                       </button>
                       <button
                         onClick={() => dispatch(setEditingId(null))}
-                        className="text-xs px-2 py-1 border border-[#2e3140] text-slate-400 hover:text-white rounded"
                       >
                         Cancel
                       </button>
                     </>
                   ) : (
                     <>
-                      <kbd className="bg-[#2a2d35] border border-[#3a3f50] rounded px-2 py-0.5 text-xs font-mono text-slate-300">
-                        {hotkey.keys}
-                      </kbd>
+                      <kbd>{hotkey.keys}</kbd>
                       <button
-                        onClick={() => { dispatch(setEditingId(hotkey.id)); setEditKeys(hotkey.keys); setError(""); }}
-                        className="text-xs text-slate-500 hover:text-violet-400 transition-colors"
+                        onClick={() => {
+                          dispatch(setEditingId(hotkey.id));
+                          setEditKeys(hotkey.keys || "");
+                          setError("");
+                        }}
                       >
                         Edit
                       </button>
                       <button
-                        onClick={() => dispatch(deleteHotkey(hotkey.id))}
-                        className="text-xs text-slate-500 hover:text-red-400 transition-colors"
+                        onClick={() =>
+                          dispatch(deleteHotkey(hotkey.id))
+                        }
                       >
                         Delete
                       </button>
@@ -152,36 +186,27 @@ export default function HotkeyManager({ isOpen, onClose }: Props) {
             </div>
           </div>
 
-          {/* Create new hotkey */}
+          {/* Create */}
           <div>
-            <p className="text-xs font-semibold text-slate-400 uppercase tracking-widest mb-2">
-              Add new hotkey
-            </p>
-            <div className="space-y-2">
-              <input
-                value={newAction}
-                onChange={e => setNewAction(e.target.value)}
-                placeholder="Action name (e.g. Toggle Sidebar)"
-                className="w-full bg-[#0e0f11] border border-[#2e3140] rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-violet-500"
-              />
-              <input
-                value={newKeys}
-                onChange={e => setNewKeys(e.target.value)}
-                placeholder="Keys (e.g. ctrl+shift+s)"
-                className="w-full bg-[#0e0f11] border border-[#2e3140] rounded-lg px-3 py-2 text-xs text-white focus:outline-none focus:border-violet-500"
-              />
-              {error && (
-                <p className="text-xs text-red-400">{error}</p>
-              )}
-              <button
-                onClick={handleCreate}
-                className="w-full py-2 bg-violet-600 hover:bg-violet-700 text-white text-xs font-medium rounded-lg transition-colors"
-              >
-                Add Hotkey
-              </button>
-            </div>
+            <input
+              value={newAction}
+              onChange={(e) => {
+                setNewAction(e.target.value);
+                setError("");
+              }}
+              placeholder="Action name"
+            />
+            <input
+              value={newKeys}
+              onChange={(e) => {
+                setNewKeys(e.target.value);
+                setError("");
+              }}
+              placeholder="Keys"
+            />
+            {error && <p className="text-red-400 text-xs">{error}</p>}
+            <button onClick={handleCreate}>Add Hotkey</button>
           </div>
-
         </div>
       </div>
     </div>

--- a/graphyne-client/src/pages/EditorPage.tsx
+++ b/graphyne-client/src/pages/EditorPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { MonitorPlay, Loader2, Save, FolderOpen, Database, Sparkles,} from "lucide-react";
+import { MonitorPlay, Loader2, Save, FolderOpen, Database, Sparkles} from "lucide-react";
 
 // 1. Imports for Logic
 import { useAppSelector, useAppDispatch } from "../store/hooks";

--- a/graphyne-client/src/pages/EditorPage.tsx
+++ b/graphyne-client/src/pages/EditorPage.tsx
@@ -40,10 +40,8 @@ export function EditorPage() {
   const [isProjectMgrOpen, setProjectMgrOpen] = useState(false);
   const [isDataMgrOpen, setDataMgrOpen] = useState(false); // NEW: Data Source Manager modal
   const [isAiPanelOpen, setAiPanelOpen] = useState(false);
-  <HotkeyManager
-  isOpen={isHotkeyMgrOpen}
-  onClose={() => setHotkeyMgrOpen(false)}
-/>
+
+
 
   // 4. Fetch Projects on Mount + Connect Socket for live data preview
   useEffect(() => {
@@ -158,6 +156,11 @@ export function EditorPage() {
         isOpen={isAiPanelOpen}
         onClose={() => setAiPanelOpen(false)}
       />
+
+      <HotkeyManager
+      isOpen={isHotkeyMgrOpen}
+      onClose={() => setHotkeyMgrOpen(false)}
+     />
 
       {/* --- HEADER --- */}
       <header className="h-20 bg-neutral-950 border-b border-none flex flex-col justify-center z-20">
@@ -296,14 +299,5 @@ export function EditorPage() {
   );
 }
 
-// Add import
 
-
-// Add state
-
-
-// Add modal in the modals section
-
-
-// Add button in the header alongside PROJECTS, DATA etc.
 

--- a/graphyne-client/src/pages/EditorPage.tsx
+++ b/graphyne-client/src/pages/EditorPage.tsx
@@ -23,10 +23,12 @@ import type { DataUpdatePayload, DataErrorPayload, DataField } from "../types/da
 import { AiDesignPanel } from "../components/UI/AiDesignPanel";
 
 import transLogo from "../assets/TransLogo.png";
+import HotkeyManager from "../components/UI/HotkeyManager";
 
 export function EditorPage() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const [isHotkeyMgrOpen, setHotkeyMgrOpen] = useState(false);
 
   // 3. Access Redux State (wrapped in .present due to redux-undo)
   const { config, elements, selectedIds, meta } = useAppSelector(
@@ -38,6 +40,10 @@ export function EditorPage() {
   const [isProjectMgrOpen, setProjectMgrOpen] = useState(false);
   const [isDataMgrOpen, setDataMgrOpen] = useState(false); // NEW: Data Source Manager modal
   const [isAiPanelOpen, setAiPanelOpen] = useState(false);
+  <HotkeyManager
+  isOpen={isHotkeyMgrOpen}
+  onClose={() => setHotkeyMgrOpen(false)}
+/>
 
   // 4. Fetch Projects on Mount + Connect Socket for live data preview
   useEffect(() => {
@@ -197,6 +203,15 @@ export function EditorPage() {
                    PROJECTS
                </button>
 
+               <button
+                onClick={() => setHotkeyMgrOpen(true)}
+                className="flex items-center gap-2 px-3 py-1.5 bg-indigo-900/30 hover:bg-indigo-800/50 text-indigo-300 border border-indigo-800/50 rounded text-xs font-bold transition-colors"
+              >
+
+                  <FolderOpen size={14} />
+                    HOTKEYS
+                  </button>
+
               {/* NEW: Data Source Manager Button */}
               <button 
                  onClick={() => setDataMgrOpen(true)}
@@ -280,3 +295,15 @@ export function EditorPage() {
     </div>
   );
 }
+
+// Add import
+
+
+// Add state
+
+
+// Add modal in the modals section
+
+
+// Add button in the header alongside PROJECTS, DATA etc.
+

--- a/graphyne-client/src/services/hotkeyService.ts
+++ b/graphyne-client/src/services/hotkeyService.ts
@@ -1,0 +1,25 @@
+import type { Hotkey } from "../types/hotkey";
+
+const BASE = "http://localhost:3001/api/hotkeys";
+
+export const hotkeyService = {
+  fetchAll: (): Promise<Hotkey[]> =>
+    fetch(BASE).then(r => r.json()),
+
+  create: (action: string, keys: string): Promise<Hotkey> =>
+    fetch(BASE, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action, keys }),
+    }).then(r => r.json()),
+
+  update: (id: string, keys: string): Promise<Hotkey> =>
+    fetch(`${BASE}/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keys }),
+    }).then(r => r.json()),
+
+  remove: (id: string): Promise<void> =>
+    fetch(`${BASE}/${id}`, { method: "DELETE" }).then(() => {}),
+};

--- a/graphyne-client/src/store/hotkeySlice.ts
+++ b/graphyne-client/src/store/hotkeySlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { hotkeyService } from "../services/hotkeyService";
-import type {HotkeyState } from "../types/hotkey";
+import type { HotkeyState } from "../types/hotkey";
 
 const initialState: HotkeyState = {
   items: [],
@@ -9,27 +9,58 @@ const initialState: HotkeyState = {
   editingId: null,
 };
 
-export const fetchHotkeys = createAsyncThunk("hotkeys/fetchAll", async () =>
-  hotkeyService.fetchAll()
+export const fetchHotkeys = createAsyncThunk(
+  "hotkeys/fetchAll",
+  async (_, { rejectWithValue }) => {
+    try {
+      return await hotkeyService.fetchAll();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data || "Failed to fetch hotkeys");
+    }
+  }
 );
 
 export const createHotkey = createAsyncThunk(
   "hotkeys/create",
-  async ({ action, keys }: { action: string; keys: string }) =>
-    hotkeyService.create(action, keys)
+  async (
+    { action, keys }: { action: string; keys: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      return await hotkeyService.create(action, keys);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data || "Failed to create hotkey");
+    }
+  }
 );
 
 export const updateHotkey = createAsyncThunk(
   "hotkeys/update",
-  async ({ id, keys }: { id: string; keys: string }) =>
-    hotkeyService.update(id, keys)
+  async (
+    { id, keys }: { id: string; keys: string },
+    { rejectWithValue }
+  ) => {
+    try {
+      return await hotkeyService.update(id, keys);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data || "Failed to update hotkey");
+    }
+  }
 );
 
 export const deleteHotkey = createAsyncThunk(
   "hotkeys/delete",
-  async (id: string) => {
-    await hotkeyService.remove(id);
-    return id;
+  async (id: string, { rejectWithValue }) => {
+    try {
+      await hotkeyService.remove(id);
+      return id;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data || "Failed to delete hotkey");
+    }
   }
 );
 
@@ -43,24 +74,46 @@ const hotkeySlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(fetchHotkeys.pending,    (state) => { state.status = "loading"; })
-      .addCase(fetchHotkeys.fulfilled,  (state, { payload }) => {
+      .addCase(fetchHotkeys.pending, (state) => {
+        state.status = "loading";
+      })
+      .addCase(fetchHotkeys.fulfilled, (state, { payload }) => {
         state.items = payload;
         state.status = "idle";
       })
-      .addCase(createHotkey.fulfilled,  (state, { payload }) => {
+      .addCase(fetchHotkeys.rejected, (state) => {
+        state.status = "error";
+      })
+
+      .addCase(createHotkey.pending, (state) => {
+        state.status = "saving";
+      })
+      .addCase(createHotkey.fulfilled, (state, { payload }) => {
         state.items.push(payload);
         state.status = "idle";
       })
-      .addCase(updateHotkey.pending,    (state) => { state.status = "saving"; })
-      .addCase(updateHotkey.fulfilled,  (state, { payload }) => {
-        const i = state.items.findIndex(h => h.id === payload.id);
+      .addCase(createHotkey.rejected, (state) => {
+        state.status = "error";
+      })
+
+      .addCase(updateHotkey.pending, (state) => {
+        state.status = "saving";
+      })
+      .addCase(updateHotkey.fulfilled, (state, { payload }) => {
+        const i = state.items.findIndex((h) => h.id === payload.id);
         if (i !== -1) state.items[i] = payload;
         state.status = "idle";
         state.editingId = null;
       })
-      .addCase(deleteHotkey.fulfilled,  (state, { payload }) => {
-        state.items = state.items.filter(h => h.id !== payload);
+      .addCase(updateHotkey.rejected, (state) => {
+        state.status = "error";
+      })
+
+      .addCase(deleteHotkey.fulfilled, (state, { payload }) => {
+        state.items = state.items.filter((h) => h.id !== payload);
+      })
+      .addCase(deleteHotkey.rejected, (state) => {
+        state.status = "error";
       });
   },
 });

--- a/graphyne-client/src/store/hotkeySlice.ts
+++ b/graphyne-client/src/store/hotkeySlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { hotkeyService } from "../services/hotkeyService";
-import type { Hotkey, HotkeyState } from "../types/hotkey";
+import type {HotkeyState } from "../types/hotkey";
 
 const initialState: HotkeyState = {
   items: [],

--- a/graphyne-client/src/store/hotkeySlice.ts
+++ b/graphyne-client/src/store/hotkeySlice.ts
@@ -1,0 +1,69 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { hotkeyService } from "../services/hotkeyService";
+import type { Hotkey, HotkeyState } from "../types/hotkey";
+
+const initialState: HotkeyState = {
+  items: [],
+  status: "idle",
+  editingId: null,
+};
+
+export const fetchHotkeys = createAsyncThunk("hotkeys/fetchAll", async () =>
+  hotkeyService.fetchAll()
+);
+
+export const createHotkey = createAsyncThunk(
+  "hotkeys/create",
+  async ({ action, keys }: { action: string; keys: string }) =>
+    hotkeyService.create(action, keys)
+);
+
+export const updateHotkey = createAsyncThunk(
+  "hotkeys/update",
+  async ({ id, keys }: { id: string; keys: string }) =>
+    hotkeyService.update(id, keys)
+);
+
+export const deleteHotkey = createAsyncThunk(
+  "hotkeys/delete",
+  async (id: string) => {
+    await hotkeyService.remove(id);
+    return id;
+  }
+);
+
+const hotkeySlice = createSlice({
+  name: "hotkeys",
+  initialState,
+  reducers: {
+    setEditingId(state, action: PayloadAction<string | null>) {
+      state.editingId = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchHotkeys.pending,    (state) => { state.status = "loading"; })
+      .addCase(fetchHotkeys.fulfilled,  (state, { payload }) => {
+        state.items = payload;
+        state.status = "idle";
+      })
+      .addCase(createHotkey.fulfilled,  (state, { payload }) => {
+        state.items.push(payload);
+        state.status = "idle";
+      })
+      .addCase(updateHotkey.pending,    (state) => { state.status = "saving"; })
+      .addCase(updateHotkey.fulfilled,  (state, { payload }) => {
+        const i = state.items.findIndex(h => h.id === payload.id);
+        if (i !== -1) state.items[i] = payload;
+        state.status = "idle";
+        state.editingId = null;
+      })
+      .addCase(deleteHotkey.fulfilled,  (state, { payload }) => {
+        state.items = state.items.filter(h => h.id !== payload);
+      });
+  },
+});
+
+export const { setEditingId } = hotkeySlice.actions;
+export default hotkeySlice.reducer;

--- a/graphyne-client/src/store/store.ts
+++ b/graphyne-client/src/store/store.ts
@@ -5,6 +5,7 @@ import dataReducer from './dataSlice';
 import { undoFilter, undoGroupBy } from './undoConfig'; // Import undo config
 import viewReducer from './viewSlice'; // NEW: Import view slice reducer
 import assetReducer from "./assetSlice";
+import hotkeyReducer from './hotkeySlice';
 
 export const store = configureStore({
   reducer: {
@@ -18,6 +19,7 @@ export const store = configureStore({
     }),
     data: dataReducer,
     view: viewReducer, // NEW: Added view slice for zoom and other view-only state.
+    hotkeys: hotkeyReducer,
     assets: assetReducer,
   }
 });

--- a/graphyne-client/src/types/hotkey.ts
+++ b/graphyne-client/src/types/hotkey.ts
@@ -1,0 +1,44 @@
+export type Hotkey = {
+  id: string;
+  action: string;
+  keys: string;
+  isCustom: boolean;
+};
+
+export type HotkeyState = {
+  items: Hotkey[];
+  status: "idle" | "loading" | "saving" | "error";
+  editingId: string | null;
+};
+
+// These are locked and cannot be changed by the user
+export const RESERVED_KEYS = [
+  "Delete",
+  "Backspace",
+  "Escape",
+  "ctrl+z",
+  "ctrl+shift+z",
+  "ctrl+=",
+  "ctrl++",
+  "ctrl+-",
+  "ctrl+0",
+  "ctrl+a",
+  "ctrl+d",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "shift+ArrowUp",
+  "shift+ArrowDown",
+  "shift+ArrowLeft",
+  "shift+ArrowRight",
+];
+
+// Default hotkeys users can customise or add to
+export const DEFAULT_HOTKEYS: Omit<Hotkey, "id">[] = [
+  { action: "Add Rectangle",   keys: "r",         isCustom: false },
+  { action: "Add Circle",      keys: "c",         isCustom: false },
+  { action: "Add Text",        keys: "t",         isCustom: false },
+  { action: "Toggle Grid",     keys: "g",         isCustom: false },
+  { action: "Toggle Assets",   keys: "a",         isCustom: false },
+];

--- a/graphyne-server/prisma/migrations/20260322122223_add_hotkeys/migration.sql
+++ b/graphyne-server/prisma/migrations/20260322122223_add_hotkeys/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Hotkey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "action" TEXT NOT NULL,
+    "keys" TEXT NOT NULL,
+    "isCustom" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Hotkey_action_key" ON "Hotkey"("action");

--- a/graphyne-server/prisma/schema.prisma
+++ b/graphyne-server/prisma/schema.prisma
@@ -87,9 +87,8 @@ model Asset {
 
 model Hotkey {
   id        String   @id @default(cuid())
-  action    String   @unique
-  keys      String
-  isCustom  Boolean  @default(false)
+  action    String
+  keys      String   @unique
+  isCustom  Boolean  @default(true)
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
 }

--- a/graphyne-server/prisma/schema.prisma
+++ b/graphyne-server/prisma/schema.prisma
@@ -84,3 +84,12 @@ model Asset {
   uploadedAt  DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
+
+model Hotkey {
+  id        String   @id @default(cuid())
+  action    String   @unique
+  keys      String
+  isCustom  Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/graphyne-server/src/migrations-bundle.ts
+++ b/graphyne-server/src/migrations-bundle.ts
@@ -71,4 +71,20 @@ CREATE TABLE "Asset" (
 );
 `,
   },
+  {
+    name: "20260322122223_add_hotkeys",
+    sql: `-- CreateTable
+CREATE TABLE "Hotkey" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "action" TEXT NOT NULL,
+    "keys" TEXT NOT NULL,
+    "isCustom" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Hotkey_action_key" ON "Hotkey"("action");
+`,
+  },
 ];

--- a/graphyne-server/src/routes/hotkeys.ts
+++ b/graphyne-server/src/routes/hotkeys.ts
@@ -50,7 +50,7 @@ export async function hotkeyRoutes(fastify: FastifyInstance) {
 
     const existing = await prisma.hotkey.findFirst({
       where: {
-        keys: { equals: normalisedKeys, mode: "insensitive" },
+        keys: { equals: normalisedKeys },
       },
     });
 
@@ -80,7 +80,7 @@ export async function hotkeyRoutes(fastify: FastifyInstance) {
 
     const existing = await prisma.hotkey.findFirst({
       where: {
-        keys: { equals: normalisedKeys, mode: "insensitive" },
+        keys: { equals: normalisedKeys },
         NOT: { id },
       },
     });

--- a/graphyne-server/src/routes/hotkeys.ts
+++ b/graphyne-server/src/routes/hotkeys.ts
@@ -1,57 +1,103 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma";
-import { RESERVED_KEYS } from "../types/hotkey";
-import { generateOnly } from "../services/aiPipeline";
 
-// Inline the reserved list on the server too so the API enforces it
 const RESERVED = [
-  "delete", "backspace", "escape",
-  "ctrl+z", "ctrl+shift+z",
-  "ctrl+=", "ctrl++", "ctrl+-", "ctrl+0",
-  "ctrl+a", "ctrl+d",
-  "arrowup", "arrowdown", "arrowleft", "arrowright",
-  "shift+arrowup", "shift+arrowdown", "shift+arrowleft", "shift+arrowright",
+  "delete",
+  "backspace",
+  "escape",
+  "ctrl+z",
+  "ctrl+shift+z",
+  "ctrl+=",
+  "ctrl++",
+  "ctrl+-",
+  "ctrl+0",
+  "ctrl+a",
+  "ctrl+d",
+  "arrowup",
+  "arrowdown",
+  "arrowleft",
+  "arrowright",
+  "shift+arrowup",
+  "shift+arrowdown",
+  "shift+arrowleft",
+  "shift+arrowright",
 ];
 
-const isReserved = (keys: string) => RESERVED.includes(keys.toLowerCase().trim());
+const normalise = (keys: string) => keys.toLowerCase().trim();
+const isReserved = (keys: string) => RESERVED.includes(normalise(keys));
 
 export async function hotkeyRoutes(fastify: FastifyInstance) {
-
-  // READ
   fastify.get("/api/hotkeys", async (_req, reply) => {
-    const hotkeys = await prisma.hotkey.findMany({ orderBy: { createdAt: "asc" } });
+    const hotkeys = await prisma.hotkey.findMany({
+      orderBy: { createdAt: "asc" },
+    });
     return reply.send(hotkeys);
   });
 
-  // CREATE
   fastify.post("/api/hotkeys", async (req, reply) => {
-    const { action, keys } = req.body as { action: string; keys: string };
-    if (!action || !keys) return reply.code(400).send({ error: "action and keys are required" });
-    if (isReserved(keys)) return reply.code(400).send({ error: "Key combination is reserved" });
+    const { action, keys } = req.body as {
+      action: string;
+      keys: string;
+    };
 
-    const existing = await prisma.hotkey.findFirst({ where: { keys: { equals: keys, mode: "insensitive" } } });
-    if (existing) return reply.code(400).send({ error: "Key combination already assigned" });
+    if (!action || !keys)
+      return reply.code(400).send({ error: "action and keys are required" });
 
-    const hotkey = await prisma.hotkey.create({ data: { action, keys, isCustom: true } });
+    const normalisedKeys = normalise(keys);
+
+    if (isReserved(normalisedKeys))
+      return reply.code(400).send({ error: "Key combination is reserved" });
+
+    const existing = await prisma.hotkey.findFirst({
+      where: {
+        keys: { equals: normalisedKeys, mode: "insensitive" },
+      },
+    });
+
+    if (existing)
+      return reply
+        .code(400)
+        .send({ error: "Key combination already assigned" });
+
+    const hotkey = await prisma.hotkey.create({
+      data: { action, keys: normalisedKeys, isCustom: true },
+    });
+
     return reply.code(201).send(hotkey);
   });
 
-  // UPDATE
   fastify.patch("/api/hotkeys/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const { keys } = req.body as { keys: string };
-    if (isReserved(keys)) return reply.code(400).send({ error: "Key combination is reserved" });
+
+    if (!keys)
+      return reply.code(400).send({ error: "keys are required" });
+
+    const normalisedKeys = normalise(keys);
+
+    if (isReserved(normalisedKeys))
+      return reply.code(400).send({ error: "Key combination is reserved" });
 
     const existing = await prisma.hotkey.findFirst({
-      where: { keys: { equals: keys, mode: "insensitive" }, NOT: { id } }
+      where: {
+        keys: { equals: normalisedKeys, mode: "insensitive" },
+        NOT: { id },
+      },
     });
-    if (existing) return reply.code(400).send({ error: "Key combination already assigned" });
 
-    const hotkey = await prisma.hotkey.update({ where: { id }, data: { keys, isCustom: true } });
+    if (existing)
+      return reply
+        .code(400)
+        .send({ error: "Key combination already assigned" });
+
+    const hotkey = await prisma.hotkey.update({
+      where: { id },
+      data: { keys: normalisedKeys, isCustom: true },
+    });
+
     return reply.send(hotkey);
   });
 
-  // DELETE — resets to default (removes custom entry)
   fastify.delete("/api/hotkeys/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     await prisma.hotkey.delete({ where: { id } });

--- a/graphyne-server/src/routes/hotkeys.ts
+++ b/graphyne-server/src/routes/hotkeys.ts
@@ -1,0 +1,60 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma";
+import { RESERVED_KEYS } from "../types/hotkey";
+import { generateOnly } from "../services/aiPipeline";
+
+// Inline the reserved list on the server too so the API enforces it
+const RESERVED = [
+  "delete", "backspace", "escape",
+  "ctrl+z", "ctrl+shift+z",
+  "ctrl+=", "ctrl++", "ctrl+-", "ctrl+0",
+  "ctrl+a", "ctrl+d",
+  "arrowup", "arrowdown", "arrowleft", "arrowright",
+  "shift+arrowup", "shift+arrowdown", "shift+arrowleft", "shift+arrowright",
+];
+
+const isReserved = (keys: string) => RESERVED.includes(keys.toLowerCase().trim());
+
+export async function hotkeyRoutes(fastify: FastifyInstance) {
+
+  // READ
+  fastify.get("/api/hotkeys", async (_req, reply) => {
+    const hotkeys = await prisma.hotkey.findMany({ orderBy: { createdAt: "asc" } });
+    return reply.send(hotkeys);
+  });
+
+  // CREATE
+  fastify.post("/api/hotkeys", async (req, reply) => {
+    const { action, keys } = req.body as { action: string; keys: string };
+    if (!action || !keys) return reply.code(400).send({ error: "action and keys are required" });
+    if (isReserved(keys)) return reply.code(400).send({ error: "Key combination is reserved" });
+
+    const existing = await prisma.hotkey.findFirst({ where: { keys: { equals: keys, mode: "insensitive" } } });
+    if (existing) return reply.code(400).send({ error: "Key combination already assigned" });
+
+    const hotkey = await prisma.hotkey.create({ data: { action, keys, isCustom: true } });
+    return reply.code(201).send(hotkey);
+  });
+
+  // UPDATE
+  fastify.patch("/api/hotkeys/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { keys } = req.body as { keys: string };
+    if (isReserved(keys)) return reply.code(400).send({ error: "Key combination is reserved" });
+
+    const existing = await prisma.hotkey.findFirst({
+      where: { keys: { equals: keys, mode: "insensitive" }, NOT: { id } }
+    });
+    if (existing) return reply.code(400).send({ error: "Key combination already assigned" });
+
+    const hotkey = await prisma.hotkey.update({ where: { id }, data: { keys, isCustom: true } });
+    return reply.send(hotkey);
+  });
+
+  // DELETE — resets to default (removes custom entry)
+  fastify.delete("/api/hotkeys/:id", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    await prisma.hotkey.delete({ where: { id } });
+    return reply.code(204).send();
+  });
+}

--- a/graphyne-server/src/server.ts
+++ b/graphyne-server/src/server.ts
@@ -11,6 +11,7 @@ import { datasourceRoutes } from './routes/datasources';
 import { DataPollerService } from './services/dataPoller';
 import { aiRoutes } from './routes/ai';
 import { assetRoutes } from "./routes/assets"; 
+import {hotkeyRoutes} from  './routes/hotkeys';
 
 // ── Detect pkg binary ──────────────────────────────────────────────────────────
 const isPkg = Object.prototype.hasOwnProperty.call(process, 'pkg');
@@ -149,6 +150,7 @@ async function runMigrations() {
 const app = Fastify({ logger: true });
 
 // ── Plugins ────────────────────────────────────────────────────────────────────
+app.register(hotkeyRoutes);
 app.register(cors, { origin: '*' });
 app.register(multipart);
 
@@ -303,5 +305,6 @@ const start = async () => {
     process.exit(1);
   }
 };
+
 
 start();

--- a/graphyne-server/src/types/hotkey.ts
+++ b/graphyne-server/src/types/hotkey.ts
@@ -1,0 +1,44 @@
+export type Hotkey = {
+  id: string;
+  action: string;
+  keys: string;
+  isCustom: boolean;
+};
+
+export type HotkeyState = {
+  items: Hotkey[];
+  status: "idle" | "loading" | "saving" | "error";
+  editingId: string | null;
+};
+
+// These are locked and cannot be changed by the user
+export const RESERVED_KEYS = [
+  "Delete",
+  "Backspace",
+  "Escape",
+  "ctrl+z",
+  "ctrl+shift+z",
+  "ctrl+=",
+  "ctrl++",
+  "ctrl+-",
+  "ctrl+0",
+  "ctrl+a",
+  "ctrl+d",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "shift+ArrowUp",
+  "shift+ArrowDown",
+  "shift+ArrowLeft",
+  "shift+ArrowRight",
+];
+
+// Default hotkeys users can customise or add to
+export const DEFAULT_HOTKEYS: Omit<Hotkey, "id">[] = [
+  { action: "Add Rectangle",   keys: "r",         isCustom: false },
+  { action: "Add Circle",      keys: "c",         isCustom: false },
+  { action: "Add Text",        keys: "t",         isCustom: false },
+  { action: "Toggle Grid",     keys: "g",         isCustom: false },
+  { action: "Toggle Assets",   keys: "a",         isCustom: false },
+];


### PR DESCRIPTION
## Fix: Add Missing Hotkey Model to Prisma Schema

### What Changed
Added the `Hotkey` model to `schema.prisma` to fix the error:
```
Property 'hotkey' does not exist on type 'PrismaClient'
```

### Schema Addition
```prisma
model Hotkey {
  id        String   @id @default(cuid())
  action    String
  keys      String   @unique
  isCustom  Boolean  @default(true)
  createdAt DateTime @default(now())
}
```

### Setup Required
After pulling this PR:
```bash
npx prisma generate
npx prisma db push
npm run dev
```

Prisma generates client accessors based on your schema models. Without the `Hotkey` model defined, `prisma.hotkey` doesn't exist, causing TypeScript errors.

This PR adds the model and regenerates the Prisma client with the correct types.